### PR TITLE
Fix/unstack ts warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ and the versioning aim to respect [Semantic Versioning](http://semver.org/spec/v
 - Fix panel settings for large batteries
 - Add additional captions to MaStR captions
 - Use LTS version of OSM
+- The unstacking of time series in esys was fixed so that warning is given if
+  there is at least one value in columns 'source' or 'comment'
 
 ### Removed
 

--- a/digipipe/esys/esys/tools/data_processing.py
+++ b/digipipe/esys/esys/tools/data_processing.py
@@ -1099,7 +1099,7 @@ def unstack_timeseries(df):
     lost_columns = ["source", "comment"]
     for col in lost_columns:
         if col in list(df.columns):
-            if not _df[col].isna().any() or _df[col].values.any() == "None":
+            if not _df[col].isna().all() or _df[col].values.all() == "None":
                 logger.warning(
                     f"Caution any remarks in column '{col}' are lost after "
                     f"unstacking."


### PR DESCRIPTION
With this PR the unstacking function while processing the time series of the esys is fixed so that warning is given if there is at least one value in columns `source` or `comment`.

## Before merging into `dev`-branch, please make sure that the following points are checked:

- [x] All pre-commit tests passed locally with: `pre-commit run -a` **!!!** Only with PR https://github.com/rl-institut-private/digipipe/pull/168 **!!!**
- [x] File `CHANGELOG.md` was updated
- ~[ ] The docs were updated~
  - ~[ ] if `dataset.md`s were updated, the dataset docs were regenerated using~
    ~`python docs/generate_dataset_mds.py`~

If packages were modified:
- ~[ ] File `poetry.lock` was updated with: `poetry lock`~
- ~[ ] A new env was successfully set up~

If data flow was adjusted:
- ~[ ] Data pipeline run finished successfully with: `snakemake -jX`~
- [x] Esys appdata was created successfully with: `snakemake -jX make_esys_appdata`

  (with `X` =  desired number of cores, e.g. 1)
