### PR TITLE
Features/#178 remove redundant sliders from datapackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,3 +138,4 @@ and the versioning aim to respect [Semantic Versioning](http://semver.org/spec/v
 - Obsolete targets from rule all
 - Merge dataset costs_efficiencies into technology_data
 - Merge dataset costs_efficiencies into technology_data
+- Remove values for redundant subsliders from app datapackage

--- a/digipipe/store/datasets/app_settings/config.yml
+++ b/digipipe/store/datasets/app_settings/config.yml
@@ -155,12 +155,6 @@ panel_settings_templates:
       start: none
       step: none
       status_quo: none
-    s_s_g_3:
-      max: none
-      min: none
-      start: none
-      step: none
-      status_quo: none
 
   heat_settings_panel:
     w_d_wp_1:
@@ -186,13 +180,6 @@ panel_settings_templates:
       start: none
       step: none
     w_z_wp_1:
-      max: none
-      min: none
-      start: none
-      step: none
-      status_quo: none
-      # future_scenario: none
-    w_z_wp_3:
       max: none
       min: none
       start: none
@@ -232,17 +219,7 @@ panel_settings_templates:
       min: none
       start: none
       step: none
-    w_d_s_3:
-      max: none
-      min: none
-      start: none
-      step: none
     w_z_s_1:
-      max: none
-      min: none
-      start: none
-      step: none
-    w_z_s_3:
       max: none
       min: none
       start: none

--- a/digipipe/store/datasets/app_settings/scripts/panels.py
+++ b/digipipe/store/datasets/app_settings/scripts/panels.py
@@ -314,21 +314,6 @@ def add_electricity_panel_settings(
                     * 100,
                 ),
             ),
-            s_s_g_3=dict(
-                max=50,
-                min=0,
-                start=math.ceil(
-                    storage_large_stats.storage_capacity.sum()
-                    / feedin_wind_pv_daily_mean
-                    * 100,
-                ),
-                step=1,
-                status_quo=math.ceil(
-                    storage_large_stats.storage_capacity.sum()
-                    / feedin_wind_pv_daily_mean
-                    * 100,
-                ),
-            ),
         )
     )
 
@@ -376,15 +361,6 @@ def add_heat_panel_settings(
                 step=5,
             ),
             w_z_wp_1=dict(
-                max=100,
-                min=0,
-                start=round(heat_pump_share.loc[2022] * 100),
-                step=5,
-                status_quo=round(heat_pump_share.loc[2022] * 100),
-                # TODO: Insert cen heating structure targets
-                # future_scenario=0,
-            ),
-            w_z_wp_3=dict(
                 max=100,
                 min=0,
                 start=round(heat_pump_share.loc[2022] * 100),
@@ -458,19 +434,7 @@ def add_heat_panel_settings(
                 start=100,
                 step=5,
             ),
-            w_d_s_3=dict(
-                max=200,
-                min=25,
-                start=100,
-                step=5,
-            ),
             w_z_s_1=dict(
-                max=200,
-                min=25,
-                start=100,
-                step=5,
-            ),
-            w_z_s_3=dict(
                 max=200,
                 min=25,
                 start=100,


### PR DESCRIPTION
Fixes #178

## Before merging into `dev`-branch, please make sure that the following points are checked:

- [x] All pre-commit tests passed locally with: `pre-commit run -a`
- [x] File `CHANGELOG.md` was updated
- [ ] The docs were updated
  - [ ] if `dataset.md`s were updated, the dataset docs were regenerated using
    `python docs/generate_dataset_mds.py`

If packages were modified:
- [ ] File `poetry.lock` was updated with: `poetry lock`
- [ ] A new env was successfully set up

If data flow was adjusted:
- [ ] Data pipeline run finished successfully with: `snakemake -jX`
- [ ] Esys appdata was created successfully with: `snakemake -jX make_esys_appdata`

  (with `X` =  desired number of cores, e.g. 1)
