### PR TITLE
#44 centralize region configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and the versioning aim to respect [Semantic Versioning](http://semver.org/spec/v
 - Add notes on OSM download and run resources
 - Add nominal power per wind turbine for 2045
 - Add technology data for batteries
+- Add definition of relevant regions (NUTS3) in global configuration file 
 
 ### Changed
 
@@ -135,6 +136,8 @@ and the versioning aim to respect [Semantic Versioning](http://semver.org/spec/v
 - Restrict snakemake version to v7.32.0
 - Add central heat pump targets to slider
 - Restrict heat pump sliders to not move under 50%
+- Adapt existing dataset rules to use the global region definition (NUTS3)
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ and the versioning aim to respect [Semantic Versioning](http://semver.org/spec/v
 - Add notes on OSM download and run resources
 - Add nominal power per wind turbine for 2045
 - Add technology data for batteries
-- Add definition of relevant regions (NUTS3) in global configuration file 
+- Add definition of relevant regions (NUTS3) in global configuration file
 
 ### Changed
 

--- a/digipipe/config/global.yml
+++ b/digipipe/config/global.yml
@@ -11,9 +11,9 @@ geodata:
   geocoder:
     user_agent: "geocoder"
     interval_sec: 1
-  NUTS: 
-    - "DEE01"
-    - "DEE05"
-    - "DEE0E"
+  # Define NUTS3 codes for region of interest 
+  nuts: 
+    - "DE409"
+    - "DE40C"
 input_data:
   download_url: "https://wolke.rl-institut.de/s/aN2ccptGtFsFiDs/download"

--- a/digipipe/config/global.yml
+++ b/digipipe/config/global.yml
@@ -11,8 +11,8 @@ geodata:
   geocoder:
     user_agent: "geocoder"
     interval_sec: 1
-  # Define NUTS3 codes for region of interest 
-  nuts: 
+  # Define NUTS3 codes for region of interest
+  nuts:
     - "DEE01"
     - "DEE05"
     - "DEE0E"

--- a/digipipe/config/global.yml
+++ b/digipipe/config/global.yml
@@ -13,7 +13,8 @@ geodata:
     interval_sec: 1
   # Define NUTS3 codes for region of interest 
   nuts: 
-    - "DE409"
-    - "DE40C"
+    - "DEE01"
+    - "DEE05"
+    - "DEE0E"
 input_data:
   download_url: "https://wolke.rl-institut.de/s/aN2ccptGtFsFiDs/download"

--- a/digipipe/config/global.yml
+++ b/digipipe/config/global.yml
@@ -11,6 +11,9 @@ geodata:
   geocoder:
     user_agent: "geocoder"
     interval_sec: 1
-
+  NUTS: 
+    - "DEE01"
+    - "DEE05"
+    - "DEE0E"
 input_data:
   download_url: "https://wolke.rl-institut.de/s/aN2ccptGtFsFiDs/download"

--- a/digipipe/store/datasets/bkg_vg250_districts_region/config.yml
+++ b/digipipe/store/datasets/bkg_vg250_districts_region/config.yml
@@ -9,5 +9,4 @@ attributes:
    "GEN": "name",
    "geometry": "geometry"}
 attributes_filter:
-  {"GF": 4,
-   "NUTS": ["DEE01", "DEE05", "DEE0E"]}
+  {"GF": 4}

--- a/digipipe/store/datasets/bkg_vg250_districts_region/scripts/create.py
+++ b/digipipe/store/datasets/bkg_vg250_districts_region/scripts/create.py
@@ -2,6 +2,7 @@ import sys
 
 import geopandas as gpd
 
+from digipipe.config import GLOBAL_CONFIG
 from digipipe.scripts.config import read_config
 from digipipe.scripts.geo import (
     convert_to_multipolygon,
@@ -9,7 +10,6 @@ from digipipe.scripts.geo import (
     reproject_simplify,
     write_geofile,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process():

--- a/digipipe/store/datasets/bkg_vg250_districts_region/scripts/create.py
+++ b/digipipe/store/datasets/bkg_vg250_districts_region/scripts/create.py
@@ -9,6 +9,7 @@ from digipipe.scripts.geo import (
     reproject_simplify,
     write_geofile,
 )
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process():
@@ -37,5 +38,8 @@ def process():
 if __name__ == "__main__":
     infile = sys.argv[1]
     config = read_config(sys.argv[2])
+    config["attributes_filter"]["NUTS"] = GLOBAL_CONFIG["global"]["geodata"][
+        "NUTS"
+    ]
     outfile = sys.argv[3]
     process()

--- a/digipipe/store/datasets/bkg_vg250_districts_region/scripts/create.py
+++ b/digipipe/store/datasets/bkg_vg250_districts_region/scripts/create.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     infile = sys.argv[1]
     config = read_config(sys.argv[2])
     config["attributes_filter"]["NUTS"] = GLOBAL_CONFIG["global"]["geodata"][
-        "NUTS"
+        "nuts"
     ]
     outfile = sys.argv[3]
     process()

--- a/digipipe/store/datasets/bkg_vg250_federal_states/scripts/create.py
+++ b/digipipe/store/datasets/bkg_vg250_federal_states/scripts/create.py
@@ -9,6 +9,7 @@ from digipipe.scripts.geo import (
     reproject_simplify,
     write_geofile,
 )
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process():
@@ -37,5 +38,8 @@ def process():
 if __name__ == "__main__":
     infile = sys.argv[1]
     config = read_config(sys.argv[2])
+    config["attributes_filter"]["NUTS"] = GLOBAL_CONFIG["global"]["geodata"][
+        "NUTS"
+    ]
     outfile = sys.argv[3]
     process()

--- a/digipipe/store/datasets/bkg_vg250_federal_states/scripts/create.py
+++ b/digipipe/store/datasets/bkg_vg250_federal_states/scripts/create.py
@@ -9,7 +9,6 @@ from digipipe.scripts.geo import (
     reproject_simplify,
     write_geofile,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process():
@@ -38,8 +37,5 @@ def process():
 if __name__ == "__main__":
     infile = sys.argv[1]
     config = read_config(sys.argv[2])
-    config["attributes_filter"]["NUTS"] = GLOBAL_CONFIG["global"]["geodata"][
-        "NUTS"
-    ]
     outfile = sys.argv[3]
     process()

--- a/digipipe/store/datasets/bkg_vg250_muns_region/config.yml
+++ b/digipipe/store/datasets/bkg_vg250_muns_region/config.yml
@@ -9,5 +9,4 @@ attributes:
    "GEN": "name",
    "geometry": "geometry"}
 attributes_filter:
-  {"GF": 4,
-   "NUTS": ["DEE01", "DEE05", "DEE0E"]}
+  {"GF": 4}

--- a/digipipe/store/datasets/bkg_vg250_muns_region/scripts/create.py
+++ b/digipipe/store/datasets/bkg_vg250_muns_region/scripts/create.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
 
+from digipipe.config import GLOBAL_CONFIG
 from digipipe.scripts.geo import (
     convert_to_multipolygon,
     overlay,
@@ -7,7 +8,6 @@ from digipipe.scripts.geo import (
     reproject_simplify,
     write_geofile,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process():

--- a/digipipe/store/datasets/bkg_vg250_muns_region/scripts/create.py
+++ b/digipipe/store/datasets/bkg_vg250_muns_region/scripts/create.py
@@ -43,6 +43,6 @@ def process():
 if __name__ == "__main__":
     config = snakemake.config
     config["attributes_filter"]["NUTS"] = GLOBAL_CONFIG["global"]["geodata"][
-        "NUTS"
+        "nuts"
     ]
     process()

--- a/digipipe/store/datasets/bkg_vg250_muns_region/scripts/create.py
+++ b/digipipe/store/datasets/bkg_vg250_muns_region/scripts/create.py
@@ -7,6 +7,7 @@ from digipipe.scripts.geo import (
     reproject_simplify,
     write_geofile,
 )
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process():
@@ -41,4 +42,7 @@ def process():
 
 if __name__ == "__main__":
     config = snakemake.config
+    config["attributes_filter"]["NUTS"] = GLOBAL_CONFIG["global"]["geodata"][
+        "NUTS"
+    ]
     process()

--- a/digipipe/store/datasets/bkg_vg250_state/scripts/create.py
+++ b/digipipe/store/datasets/bkg_vg250_state/scripts/create.py
@@ -9,6 +9,7 @@ from digipipe.scripts.geo import (
     reproject_simplify,
     write_geofile,
 )
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process():
@@ -37,5 +38,8 @@ def process():
 if __name__ == "__main__":
     infile = sys.argv[1]
     config = read_config(sys.argv[2])
+    config["attributes_filter"]["NUTS"] = GLOBAL_CONFIG["global"]["geodata"][
+        "NUTS"
+    ]
     outfile = sys.argv[3]
     process()

--- a/digipipe/store/datasets/bkg_vg250_state/scripts/create.py
+++ b/digipipe/store/datasets/bkg_vg250_state/scripts/create.py
@@ -9,7 +9,6 @@ from digipipe.scripts.geo import (
     reproject_simplify,
     write_geofile,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process():
@@ -38,8 +37,5 @@ def process():
 if __name__ == "__main__":
     infile = sys.argv[1]
     config = read_config(sys.argv[2])
-    config["attributes_filter"]["NUTS"] = GLOBAL_CONFIG["global"]["geodata"][
-        "NUTS"
-    ]
     outfile = sys.argv[3]
     process()

--- a/digipipe/store/datasets/bnetza_mastr_biomass_region/config.yml
+++ b/digipipe/store/datasets/bnetza_mastr_biomass_region/config.yml
@@ -28,8 +28,7 @@ attributes:
    "NetzbetreiberpruefungStatus": "validated_by_system_operator"}
 attributes_filter:
   {"Land": "Deutschland",
-   "EinheitBetriebsstatus": ["In Betrieb", "In Planung"],
-   "Landkreis": ["Wittenberg", "Anhalt-Bitterfeld", "Dessau-Roßlau"]}
+   "EinheitBetriebsstatus": ["In Betrieb", "In Planung"]}
 
 # Output settings
 layer: bnetza_mastr_biomass

--- a/digipipe/store/datasets/bnetza_mastr_biomass_region/create.smk
+++ b/digipipe/store/datasets/bnetza_mastr_biomass_region/create.smk
@@ -10,11 +10,14 @@ from digipipe.scripts.datasets.mastr import create_stats_per_municipality
 from digipipe.store.utils import (
     get_abs_dataset_path,
     PATH_TO_REGION_MUNICIPALITIES_GPKG,
-    PATH_TO_REGION_DISTRICTS_GPKG
+    PATH_TO_REGION_DISTRICTS_GPKG,
 )
 
 DATASET_PATH = get_abs_dataset_path("datasets", "bnetza_mastr_biomass_region")
-SOURCE_DATASET_PATH = get_abs_dataset_path("preprocessed", "bnetza_mastr", data_dir=True)
+SOURCE_DATASET_PATH = get_abs_dataset_path(
+    "preprocessed", "bnetza_mastr", data_dir=True
+)
+
 
 rule create:
     """
@@ -22,17 +25,21 @@ rule create:
     """
     input:
         units=SOURCE_DATASET_PATH / "bnetza_mastr_biomass_raw.csv",
-        locations=SOURCE_DATASET_PATH / "bnetza_mastr_locations_extended_raw.csv",
+        locations=SOURCE_DATASET_PATH
+        / "bnetza_mastr_locations_extended_raw.csv",
         gridconn=SOURCE_DATASET_PATH / "bnetza_mastr_grid_connections_raw.csv",
         region_muns=PATH_TO_REGION_MUNICIPALITIES_GPKG,
-        region_districts=PATH_TO_REGION_DISTRICTS_GPKG
+        region_districts=PATH_TO_REGION_DISTRICTS_GPKG,
     output:
         outfile=DATASET_PATH / "data" / "bnetza_mastr_biomass_region.gpkg",
-        outfile_agg=DATASET_PATH / "data" / "bnetza_mastr_biomass_agg_region.gpkg"
+        outfile_agg=DATASET_PATH
+        / "data"
+        / "bnetza_mastr_biomass_agg_region.gpkg",
     params:
-        config_file=DATASET_PATH / "config.yml"
+        config_file=DATASET_PATH / "config.yml",
     script:
         DATASET_PATH / "scripts" / "create.py"
+
 
 rule create_power_stats_muns:
     """
@@ -41,12 +48,13 @@ rule create_power_stats_muns:
     input:
         units=DATASET_PATH / "data" / "bnetza_mastr_biomass_region.gpkg",
         region_muns=PATH_TO_REGION_MUNICIPALITIES_GPKG,
-    output: DATASET_PATH / "data" / "bnetza_mastr_biomass_stats_muns.csv"
+    output:
+        DATASET_PATH / "data" / "bnetza_mastr_biomass_stats_muns.csv",
     run:
         units = create_stats_per_municipality(
             units_df=gpd.read_file(input.units),
             muns=gpd.read_file(input.region_muns),
-            column="capacity_net"
+            column="capacity_net",
         )
         units["capacity_net"] = units["capacity_net"].div(1e3)  # kW to MW
         units.to_csv(output[0])

--- a/digipipe/store/datasets/bnetza_mastr_biomass_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_biomass_region/scripts/create.py
@@ -19,7 +19,7 @@ def process() -> None:
     attrs_filter = snakemake.config["attributes_filter"]
     attrs_filter["Landkreis"] = get_names_from_nuts(
         PATH_TO_REGION_DISTRICTS_GPKG,
-        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+        GLOBAL_CONFIG["global"]["geodata"]["nuts"],
     )
 
     units = pd.read_csv(

--- a/digipipe/store/datasets/bnetza_mastr_biomass_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_biomass_region/scripts/create.py
@@ -1,6 +1,7 @@
 import geopandas as gpd
 import pandas as pd
 
+from digipipe.config import GLOBAL_CONFIG
 from digipipe.scripts.datasets import mastr
 from digipipe.scripts.geo import (
     overlay,
@@ -8,10 +9,9 @@ from digipipe.scripts.geo import (
     write_geofile,
 )
 from digipipe.store.utils import (
-    get_names_from_nuts,
     PATH_TO_REGION_DISTRICTS_GPKG,
+    get_names_from_nuts,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:

--- a/digipipe/store/datasets/bnetza_mastr_biomass_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_biomass_region/scripts/create.py
@@ -7,13 +7,21 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.store.utils import (
+    get_names_from_nuts,
+    PATH_TO_REGION_DISTRICTS_GPKG,
+)
 from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
-    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
+    attrs_filter["Landkreis"] = get_names_from_nuts(
+        PATH_TO_REGION_DISTRICTS_GPKG,
+        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+    )
+
     units = pd.read_csv(
         snakemake.input.units,
         usecols=set(attrs.keys()) | set(attrs_filter.keys()),

--- a/digipipe/store/datasets/bnetza_mastr_biomass_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_biomass_region/scripts/create.py
@@ -7,12 +7,13 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
-
+    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
     units = pd.read_csv(
         snakemake.input.units,
         usecols=set(attrs.keys()) | set(attrs_filter.keys()),

--- a/digipipe/store/datasets/bnetza_mastr_combustion_region/config.yml
+++ b/digipipe/store/datasets/bnetza_mastr_combustion_region/config.yml
@@ -30,8 +30,7 @@ attributes:
    "NetzbetreiberpruefungStatus": "validated_by_system_operator"}
 attributes_filter:
   {"Land": "Deutschland",
-   "EinheitBetriebsstatus": ["In Betrieb", "In Planung"],
-   "Landkreis": ["Wittenberg", "Anhalt-Bitterfeld", "Dessau-Roßlau"]}
+   "EinheitBetriebsstatus": ["In Betrieb", "In Planung"]}
 
 # Output settings
 layer: bnetza_mastr_combustion

--- a/digipipe/store/datasets/bnetza_mastr_combustion_region/create.smk
+++ b/digipipe/store/datasets/bnetza_mastr_combustion_region/create.smk
@@ -10,11 +10,16 @@ from digipipe.scripts.datasets.mastr import create_stats_per_municipality
 from digipipe.store.utils import (
     get_abs_dataset_path,
     PATH_TO_REGION_MUNICIPALITIES_GPKG,
-    PATH_TO_REGION_DISTRICTS_GPKG
+    PATH_TO_REGION_DISTRICTS_GPKG,
 )
 
-DATASET_PATH = get_abs_dataset_path("datasets", "bnetza_mastr_combustion_region")
-SOURCE_DATASET_PATH = get_abs_dataset_path("preprocessed", "bnetza_mastr", data_dir=True)
+DATASET_PATH = get_abs_dataset_path(
+    "datasets", "bnetza_mastr_combustion_region"
+)
+SOURCE_DATASET_PATH = get_abs_dataset_path(
+    "preprocessed", "bnetza_mastr", data_dir=True
+)
+
 
 rule create:
     """
@@ -22,17 +27,21 @@ rule create:
     """
     input:
         units=SOURCE_DATASET_PATH / "bnetza_mastr_combustion_raw.csv",
-        locations=SOURCE_DATASET_PATH / "bnetza_mastr_locations_extended_raw.csv",
+        locations=SOURCE_DATASET_PATH
+        / "bnetza_mastr_locations_extended_raw.csv",
         gridconn=SOURCE_DATASET_PATH / "bnetza_mastr_grid_connections_raw.csv",
         region_muns=PATH_TO_REGION_MUNICIPALITIES_GPKG,
-        region_districts=PATH_TO_REGION_DISTRICTS_GPKG
+        region_districts=PATH_TO_REGION_DISTRICTS_GPKG,
     output:
         outfile=DATASET_PATH / "data" / "bnetza_mastr_combustion_region.gpkg",
-        outfile_agg=DATASET_PATH / "data" / "bnetza_mastr_combustion_agg_region.gpkg"
+        outfile_agg=DATASET_PATH
+        / "data"
+        / "bnetza_mastr_combustion_agg_region.gpkg",
     params:
-        config_file=DATASET_PATH / "config.yml"
+        config_file=DATASET_PATH / "config.yml",
     script:
         DATASET_PATH / "scripts" / "create.py"
+
 
 rule create_power_stats_muns:
     """
@@ -41,12 +50,13 @@ rule create_power_stats_muns:
     input:
         units=DATASET_PATH / "data" / "bnetza_mastr_combustion_region.gpkg",
         region_muns=PATH_TO_REGION_MUNICIPALITIES_GPKG,
-    output: DATASET_PATH / "data" / "bnetza_mastr_combustion_stats_muns.csv"
+    output:
+        DATASET_PATH / "data" / "bnetza_mastr_combustion_stats_muns.csv",
     run:
         units = create_stats_per_municipality(
             units_df=gpd.read_file(input.units),
             muns=gpd.read_file(input.region_muns),
-            column="capacity_net"
+            column="capacity_net",
         )
         units["capacity_net"] = units["capacity_net"].div(1e3)  # kW to MW
         units.to_csv(output[0])

--- a/digipipe/store/datasets/bnetza_mastr_combustion_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_combustion_region/scripts/create.py
@@ -8,12 +8,13 @@ from digipipe.scripts.geo import (
     write_geofile,
 )
 from digipipe.store.utils import df_merge_string_columns
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
-
+    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
     units = pd.read_csv(
         snakemake.input.units,
         usecols=set(attrs.keys()) | set(attrs_filter.keys()),

--- a/digipipe/store/datasets/bnetza_mastr_combustion_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_combustion_region/scripts/create.py
@@ -20,7 +20,7 @@ def process() -> None:
     attrs_filter = snakemake.config["attributes_filter"]
     attrs_filter["Landkreis"] = get_names_from_nuts(
         PATH_TO_REGION_DISTRICTS_GPKG,
-        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+        GLOBAL_CONFIG["global"]["geodata"]["nuts"],
     )
     units = pd.read_csv(
         snakemake.input.units,

--- a/digipipe/store/datasets/bnetza_mastr_combustion_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_combustion_region/scripts/create.py
@@ -7,14 +7,21 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
-from digipipe.store.utils import df_merge_string_columns
+from digipipe.store.utils import (
+    df_merge_string_columns,
+    get_names_from_nuts,
+    PATH_TO_REGION_DISTRICTS_GPKG,
+)
 from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
-    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
+    attrs_filter["Landkreis"] = get_names_from_nuts(
+        PATH_TO_REGION_DISTRICTS_GPKG,
+        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+    )
     units = pd.read_csv(
         snakemake.input.units,
         usecols=set(attrs.keys()) | set(attrs_filter.keys()),

--- a/digipipe/store/datasets/bnetza_mastr_combustion_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_combustion_region/scripts/create.py
@@ -1,6 +1,7 @@
 import geopandas as gpd
 import pandas as pd
 
+from digipipe.config import GLOBAL_CONFIG
 from digipipe.scripts.datasets import mastr
 from digipipe.scripts.geo import (
     overlay,
@@ -8,11 +9,10 @@ from digipipe.scripts.geo import (
     write_geofile,
 )
 from digipipe.store.utils import (
+    PATH_TO_REGION_DISTRICTS_GPKG,
     df_merge_string_columns,
     get_names_from_nuts,
-    PATH_TO_REGION_DISTRICTS_GPKG,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:

--- a/digipipe/store/datasets/bnetza_mastr_gsgk_region/config.yml
+++ b/digipipe/store/datasets/bnetza_mastr_gsgk_region/config.yml
@@ -25,8 +25,7 @@ attributes:
    "NetzbetreiberpruefungStatus": "validated_by_system_operator"}
 attributes_filter:
   {"Land": "Deutschland",
-   "EinheitBetriebsstatus": ["In Betrieb", "In Planung"],
-   "Landkreis": ["Wittenberg", "Anhalt-Bitterfeld", "Dessau-Roßlau"]}
+   "EinheitBetriebsstatus": ["In Betrieb", "In Planung"]}
 
 # Output settings
 layer: bnetza_mastr_gsgk

--- a/digipipe/store/datasets/bnetza_mastr_gsgk_region/create.smk
+++ b/digipipe/store/datasets/bnetza_mastr_gsgk_region/create.smk
@@ -10,11 +10,14 @@ from digipipe.scripts.datasets.mastr import create_stats_per_municipality
 from digipipe.store.utils import (
     get_abs_dataset_path,
     PATH_TO_REGION_MUNICIPALITIES_GPKG,
-    PATH_TO_REGION_DISTRICTS_GPKG
+    PATH_TO_REGION_DISTRICTS_GPKG,
 )
 
 DATASET_PATH = get_abs_dataset_path("datasets", "bnetza_mastr_gsgk_region")
-SOURCE_DATASET_PATH = get_abs_dataset_path("preprocessed", "bnetza_mastr", data_dir=True)
+SOURCE_DATASET_PATH = get_abs_dataset_path(
+    "preprocessed", "bnetza_mastr", data_dir=True
+)
+
 
 rule create:
     """
@@ -22,17 +25,19 @@ rule create:
     """
     input:
         units=SOURCE_DATASET_PATH / "bnetza_mastr_gsgk_raw.csv",
-        locations=SOURCE_DATASET_PATH / "bnetza_mastr_locations_extended_raw.csv",
+        locations=SOURCE_DATASET_PATH
+        / "bnetza_mastr_locations_extended_raw.csv",
         gridconn=SOURCE_DATASET_PATH / "bnetza_mastr_grid_connections_raw.csv",
         region_muns=PATH_TO_REGION_MUNICIPALITIES_GPKG,
-        region_districts=PATH_TO_REGION_DISTRICTS_GPKG
+        region_districts=PATH_TO_REGION_DISTRICTS_GPKG,
     output:
         outfile=DATASET_PATH / "data" / "bnetza_mastr_gsgk_region.gpkg",
-        outfile_agg=DATASET_PATH / "data" / "bnetza_mastr_gsgk_agg_region.gpkg"
+        outfile_agg=DATASET_PATH / "data" / "bnetza_mastr_gsgk_agg_region.gpkg",
     params:
-        config_file=DATASET_PATH / "config.yml"
+        config_file=DATASET_PATH / "config.yml",
     script:
         DATASET_PATH / "scripts" / "create.py"
+
 
 rule create_power_stats_muns:
     """
@@ -41,12 +46,13 @@ rule create_power_stats_muns:
     input:
         units=DATASET_PATH / "data" / "bnetza_mastr_gsgk_region.gpkg",
         region_muns=PATH_TO_REGION_MUNICIPALITIES_GPKG,
-    output: DATASET_PATH / "data" / "bnetza_mastr_gsgk_stats_muns.csv"
+    output:
+        DATASET_PATH / "data" / "bnetza_mastr_gsgk_stats_muns.csv",
     run:
         units = create_stats_per_municipality(
             units_df=gpd.read_file(input.units),
             muns=gpd.read_file(input.region_muns),
-            column="capacity_net"
+            column="capacity_net",
         )
         units["capacity_net"] = units["capacity_net"].div(1e3)  # kW to MW
         units.to_csv(output[0])

--- a/digipipe/store/datasets/bnetza_mastr_gsgk_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_gsgk_region/scripts/create.py
@@ -7,11 +7,13 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
+    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
 
     units = pd.read_csv(
         snakemake.input.units,

--- a/digipipe/store/datasets/bnetza_mastr_gsgk_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_gsgk_region/scripts/create.py
@@ -19,7 +19,7 @@ def process() -> None:
     attrs_filter = snakemake.config["attributes_filter"]
     attrs_filter["Landkreis"] = get_names_from_nuts(
         PATH_TO_REGION_DISTRICTS_GPKG,
-        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+        GLOBAL_CONFIG["global"]["geodata"]["nuts"],
     )
 
     units = pd.read_csv(

--- a/digipipe/store/datasets/bnetza_mastr_gsgk_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_gsgk_region/scripts/create.py
@@ -1,6 +1,7 @@
 import geopandas as gpd
 import pandas as pd
 
+from digipipe.config import GLOBAL_CONFIG
 from digipipe.scripts.datasets import mastr
 from digipipe.scripts.geo import (
     overlay,
@@ -8,10 +9,9 @@ from digipipe.scripts.geo import (
     write_geofile,
 )
 from digipipe.store.utils import (
-    get_names_from_nuts,
     PATH_TO_REGION_DISTRICTS_GPKG,
+    get_names_from_nuts,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:

--- a/digipipe/store/datasets/bnetza_mastr_gsgk_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_gsgk_region/scripts/create.py
@@ -7,13 +7,20 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.store.utils import (
+    get_names_from_nuts,
+    PATH_TO_REGION_DISTRICTS_GPKG,
+)
 from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
-    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
+    attrs_filter["Landkreis"] = get_names_from_nuts(
+        PATH_TO_REGION_DISTRICTS_GPKG,
+        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+    )
 
     units = pd.read_csv(
         snakemake.input.units,

--- a/digipipe/store/datasets/bnetza_mastr_hydro_region/config.yml
+++ b/digipipe/store/datasets/bnetza_mastr_hydro_region/config.yml
@@ -24,8 +24,7 @@ attributes:
    "NetzbetreiberpruefungStatus": "validated_by_system_operator"}
 attributes_filter:
   {"Land": "Deutschland",
-   "EinheitBetriebsstatus": ["In Betrieb", "In Planung"],
-   "Landkreis": ["Wittenberg", "Anhalt-Bitterfeld", "Dessau-Roßlau"]}
+   "EinheitBetriebsstatus": ["In Betrieb", "In Planung"]}
 
 # Output settings
 layer: bnetza_mastr_hydro

--- a/digipipe/store/datasets/bnetza_mastr_hydro_region/create.smk
+++ b/digipipe/store/datasets/bnetza_mastr_hydro_region/create.smk
@@ -10,11 +10,14 @@ from digipipe.scripts.datasets.mastr import create_stats_per_municipality
 from digipipe.store.utils import (
     get_abs_dataset_path,
     PATH_TO_REGION_MUNICIPALITIES_GPKG,
-    PATH_TO_REGION_DISTRICTS_GPKG
+    PATH_TO_REGION_DISTRICTS_GPKG,
 )
 
 DATASET_PATH = get_abs_dataset_path("datasets", "bnetza_mastr_hydro_region")
-SOURCE_DATASET_PATH = get_abs_dataset_path("preprocessed", "bnetza_mastr", data_dir=True)
+SOURCE_DATASET_PATH = get_abs_dataset_path(
+    "preprocessed", "bnetza_mastr", data_dir=True
+)
+
 
 rule create:
     """
@@ -22,17 +25,19 @@ rule create:
     """
     input:
         units=SOURCE_DATASET_PATH / "bnetza_mastr_hydro_raw.csv",
-        locations=SOURCE_DATASET_PATH / "bnetza_mastr_locations_extended_raw.csv",
+        locations=SOURCE_DATASET_PATH
+        / "bnetza_mastr_locations_extended_raw.csv",
         gridconn=SOURCE_DATASET_PATH / "bnetza_mastr_grid_connections_raw.csv",
         region_muns=PATH_TO_REGION_MUNICIPALITIES_GPKG,
-        region_districts=PATH_TO_REGION_DISTRICTS_GPKG
+        region_districts=PATH_TO_REGION_DISTRICTS_GPKG,
     output:
         outfile=DATASET_PATH / "data" / "bnetza_mastr_hydro_region.gpkg",
-        outfile_agg=DATASET_PATH / "data" / "bnetza_mastr_hydro_agg_region.gpkg"
+        outfile_agg=DATASET_PATH / "data" / "bnetza_mastr_hydro_agg_region.gpkg",
     params:
-        config_file=DATASET_PATH / "config.yml"
+        config_file=DATASET_PATH / "config.yml",
     script:
         DATASET_PATH / "scripts" / "create.py"
+
 
 rule create_power_stats_muns:
     """
@@ -41,12 +46,13 @@ rule create_power_stats_muns:
     input:
         units=DATASET_PATH / "data" / "bnetza_mastr_hydro_region.gpkg",
         region_muns=PATH_TO_REGION_MUNICIPALITIES_GPKG,
-    output: DATASET_PATH / "data" / "bnetza_mastr_hydro_stats_muns.csv"
+    output:
+        DATASET_PATH / "data" / "bnetza_mastr_hydro_stats_muns.csv",
     run:
         units = create_stats_per_municipality(
             units_df=gpd.read_file(input.units),
             muns=gpd.read_file(input.region_muns),
-            column="capacity_net"
+            column="capacity_net",
         )
         units["capacity_net"] = units["capacity_net"].div(1e3)  # kW to MW
         units.to_csv(output[0])

--- a/digipipe/store/datasets/bnetza_mastr_hydro_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_hydro_region/scripts/create.py
@@ -7,11 +7,13 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
+    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
 
     units = pd.read_csv(
         snakemake.input.units,

--- a/digipipe/store/datasets/bnetza_mastr_hydro_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_hydro_region/scripts/create.py
@@ -19,7 +19,7 @@ def process() -> None:
     attrs_filter = snakemake.config["attributes_filter"]
     attrs_filter["Landkreis"] = get_names_from_nuts(
         PATH_TO_REGION_DISTRICTS_GPKG,
-        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+        GLOBAL_CONFIG["global"]["geodata"]["nuts"],
     )
 
     units = pd.read_csv(

--- a/digipipe/store/datasets/bnetza_mastr_hydro_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_hydro_region/scripts/create.py
@@ -1,6 +1,7 @@
 import geopandas as gpd
 import pandas as pd
 
+from digipipe.config import GLOBAL_CONFIG
 from digipipe.scripts.datasets import mastr
 from digipipe.scripts.geo import (
     overlay,
@@ -8,10 +9,9 @@ from digipipe.scripts.geo import (
     write_geofile,
 )
 from digipipe.store.utils import (
-    get_names_from_nuts,
     PATH_TO_REGION_DISTRICTS_GPKG,
+    get_names_from_nuts,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:

--- a/digipipe/store/datasets/bnetza_mastr_hydro_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_hydro_region/scripts/create.py
@@ -7,13 +7,20 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.store.utils import (
+    get_names_from_nuts,
+    PATH_TO_REGION_DISTRICTS_GPKG,
+)
 from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
-    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
+    attrs_filter["Landkreis"] = get_names_from_nuts(
+        PATH_TO_REGION_DISTRICTS_GPKG,
+        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+    )
 
     units = pd.read_csv(
         snakemake.input.units,

--- a/digipipe/store/datasets/bnetza_mastr_pv_ground_region/config.yml
+++ b/digipipe/store/datasets/bnetza_mastr_pv_ground_region/config.yml
@@ -36,8 +36,7 @@ attributes:
 attributes_filter:
   {"Land": "Deutschland",
    "EinheitBetriebsstatus": ["In Betrieb", "In Planung"],
-   "Lage": "Freifläche",
-   "Landkreis": ["Wittenberg", "Anhalt-Bitterfeld", "Dessau-Roßlau"]}
+   "Lage": "Freifläche"}
 
 # Output settings
 layer: bnetza_mastr_pv_ground

--- a/digipipe/store/datasets/bnetza_mastr_pv_ground_region/create.smk
+++ b/digipipe/store/datasets/bnetza_mastr_pv_ground_region/create.smk
@@ -72,9 +72,7 @@ rule create_development_over_time:
     capacity and cumulative number of operating units
     """
     input:
-        agg_region=DATASET_PATH
-        / "data"
-        / "bnetza_mastr_pv_ground_region.gpkg",
+        agg_region=DATASET_PATH / "data" / "bnetza_mastr_pv_ground_region.gpkg",
     output:
         DATASET_PATH
         / "data"
@@ -94,13 +92,16 @@ rule create_development_over_time:
         )
 
         df_units_cumulative = (
-            df.groupby("year").agg(
-                unit_count=("mastr_id", "count")).cumsum().reset_index()
+            df.groupby("year")
+            .agg(unit_count=("mastr_id", "count"))
+            .cumsum()
+            .reset_index()
         )
         df_combined = df_capacity_over_time.merge(
             df_units_cumulative, on="year"
         )
-        df_combined["capacity_net"] = df_combined[
-            "capacity_net"].div(1e3).round(1)
+        df_combined["capacity_net"] = (
+            df_combined["capacity_net"].div(1e3).round(1)
+        )
         df_combined["year"] = df_combined["year"].astype(int)
         df_combined.to_csv(output[0], index=False)

--- a/digipipe/store/datasets/bnetza_mastr_pv_ground_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_pv_ground_region/scripts/create.py
@@ -7,11 +7,13 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
+    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
 
     units = pd.read_csv(
         snakemake.input.units,

--- a/digipipe/store/datasets/bnetza_mastr_pv_ground_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_pv_ground_region/scripts/create.py
@@ -19,7 +19,7 @@ def process() -> None:
     attrs_filter = snakemake.config["attributes_filter"]
     attrs_filter["Landkreis"] = get_names_from_nuts(
         PATH_TO_REGION_DISTRICTS_GPKG,
-        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+        GLOBAL_CONFIG["global"]["geodata"]["nuts"],
     )
 
     units = pd.read_csv(

--- a/digipipe/store/datasets/bnetza_mastr_pv_ground_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_pv_ground_region/scripts/create.py
@@ -1,6 +1,7 @@
 import geopandas as gpd
 import pandas as pd
 
+from digipipe.config import GLOBAL_CONFIG
 from digipipe.scripts.datasets import mastr
 from digipipe.scripts.geo import (
     overlay,
@@ -8,10 +9,9 @@ from digipipe.scripts.geo import (
     write_geofile,
 )
 from digipipe.store.utils import (
-    get_names_from_nuts,
     PATH_TO_REGION_DISTRICTS_GPKG,
+    get_names_from_nuts,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:

--- a/digipipe/store/datasets/bnetza_mastr_pv_ground_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_pv_ground_region/scripts/create.py
@@ -7,13 +7,20 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.store.utils import (
+    get_names_from_nuts,
+    PATH_TO_REGION_DISTRICTS_GPKG,
+)
 from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
-    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
+    attrs_filter["Landkreis"] = get_names_from_nuts(
+        PATH_TO_REGION_DISTRICTS_GPKG,
+        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+    )
 
     units = pd.read_csv(
         snakemake.input.units,

--- a/digipipe/store/datasets/bnetza_mastr_pv_roof_region/config.yml
+++ b/digipipe/store/datasets/bnetza_mastr_pv_roof_region/config.yml
@@ -40,8 +40,7 @@ attributes_filter:
      "Bauliche Anlagen (Hausdach, Gebäude und Fassade)",
      "Bauliche Anlagen (Sonstige)",
      "Steckerfertige Erzeugungsanlage (sog. Plug-In- oder Balkon-PV-Anlage)"
-   ],
-   "Landkreis": ["Wittenberg", "Anhalt-Bitterfeld", "Dessau-Roßlau"]}
+   ]}
 
 # Output settings
 layer: bnetza_mastr_pv_roof

--- a/digipipe/store/datasets/bnetza_mastr_pv_roof_region/create.smk
+++ b/digipipe/store/datasets/bnetza_mastr_pv_roof_region/create.smk
@@ -72,9 +72,7 @@ rule create_development_over_time:
     capacity and cumulative number of operating units
     """
     input:
-        agg_region=DATASET_PATH
-        / "data"
-        / "bnetza_mastr_pv_roof_region.gpkg",
+        agg_region=DATASET_PATH / "data" / "bnetza_mastr_pv_roof_region.gpkg",
     output:
         DATASET_PATH / "data" / "bnetza_mastr_pv_roof_development_over_time.csv",
     run:
@@ -92,13 +90,16 @@ rule create_development_over_time:
         )
 
         df_units_cumulative = (
-            df.groupby("year").agg(
-                unit_count=("mastr_id", "count")).cumsum().reset_index()
+            df.groupby("year")
+            .agg(unit_count=("mastr_id", "count"))
+            .cumsum()
+            .reset_index()
         )
         df_combined = df_capacity_over_time.merge(
             df_units_cumulative, on="year"
         )
-        df_combined["capacity_net"] = df_combined[
-            "capacity_net"].div(1e3).round(1)
+        df_combined["capacity_net"] = (
+            df_combined["capacity_net"].div(1e3).round(1)
+        )
         df_combined["year"] = df_combined["year"].astype(int)
         df_combined.to_csv(output[0], index=False)

--- a/digipipe/store/datasets/bnetza_mastr_pv_roof_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_pv_roof_region/scripts/create.py
@@ -7,11 +7,13 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
+    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
 
     units = pd.read_csv(
         snakemake.input.units,

--- a/digipipe/store/datasets/bnetza_mastr_pv_roof_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_pv_roof_region/scripts/create.py
@@ -19,7 +19,7 @@ def process() -> None:
     attrs_filter = snakemake.config["attributes_filter"]
     attrs_filter["Landkreis"] = get_names_from_nuts(
         PATH_TO_REGION_DISTRICTS_GPKG,
-        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+        GLOBAL_CONFIG["global"]["geodata"]["nuts"],
     )
 
     units = pd.read_csv(

--- a/digipipe/store/datasets/bnetza_mastr_pv_roof_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_pv_roof_region/scripts/create.py
@@ -1,6 +1,7 @@
 import geopandas as gpd
 import pandas as pd
 
+from digipipe.config import GLOBAL_CONFIG
 from digipipe.scripts.datasets import mastr
 from digipipe.scripts.geo import (
     overlay,
@@ -8,10 +9,9 @@ from digipipe.scripts.geo import (
     write_geofile,
 )
 from digipipe.store.utils import (
-    get_names_from_nuts,
     PATH_TO_REGION_DISTRICTS_GPKG,
+    get_names_from_nuts,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:

--- a/digipipe/store/datasets/bnetza_mastr_pv_roof_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_pv_roof_region/scripts/create.py
@@ -7,13 +7,20 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.store.utils import (
+    get_names_from_nuts,
+    PATH_TO_REGION_DISTRICTS_GPKG,
+)
 from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
-    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
+    attrs_filter["Landkreis"] = get_names_from_nuts(
+        PATH_TO_REGION_DISTRICTS_GPKG,
+        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+    )
 
     units = pd.read_csv(
         snakemake.input.units,

--- a/digipipe/store/datasets/bnetza_mastr_storage_region/config.yml
+++ b/digipipe/store/datasets/bnetza_mastr_storage_region/config.yml
@@ -29,8 +29,7 @@ unit_attributes:
    "NetzbetreiberpruefungStatus": "validated_by_system_operator"}
 unit_attributes_filter:
   {"Land": "Deutschland",
-   "EinheitBetriebsstatus": ["In Betrieb", "In Planung"],
-   "Landkreis": ["Wittenberg", "Anhalt-Bitterfeld", "Dessau-Roßlau"]}
+   "EinheitBetriebsstatus": ["In Betrieb", "In Planung"]}
 
 plant_attributes:
   {"VerknuepfteEinheit": "unit_mastr_id",

--- a/digipipe/store/datasets/bnetza_mastr_storage_region/create.smk
+++ b/digipipe/store/datasets/bnetza_mastr_storage_region/create.smk
@@ -11,11 +11,14 @@ from digipipe.scripts.datasets.mastr import create_stats_per_municipality
 from digipipe.store.utils import (
     get_abs_dataset_path,
     PATH_TO_REGION_MUNICIPALITIES_GPKG,
-    PATH_TO_REGION_DISTRICTS_GPKG
+    PATH_TO_REGION_DISTRICTS_GPKG,
 )
 
 DATASET_PATH = get_abs_dataset_path("datasets", "bnetza_mastr_storage_region")
-SOURCE_DATASET_PATH = get_abs_dataset_path("preprocessed", "bnetza_mastr", data_dir=True)
+SOURCE_DATASET_PATH = get_abs_dataset_path(
+    "preprocessed", "bnetza_mastr", data_dir=True
+)
+
 
 rule create:
     """
@@ -24,18 +27,22 @@ rule create:
     input:
         units=SOURCE_DATASET_PATH / "bnetza_mastr_storage_raw.csv",
         units_capacity=SOURCE_DATASET_PATH / "bnetza_mastr_storage_unit_raw.csv",
-        locations=SOURCE_DATASET_PATH / "bnetza_mastr_locations_extended_raw.csv",
+        locations=SOURCE_DATASET_PATH
+        / "bnetza_mastr_locations_extended_raw.csv",
         gridconn=SOURCE_DATASET_PATH / "bnetza_mastr_grid_connections_raw.csv",
         pv_roof_units=rules.datasets_bnetza_mastr_pv_roof_region_create.output.outfile,
         region_muns=PATH_TO_REGION_MUNICIPALITIES_GPKG,
-        region_districts=PATH_TO_REGION_DISTRICTS_GPKG
+        region_districts=PATH_TO_REGION_DISTRICTS_GPKG,
     output:
         outfile=DATASET_PATH / "data" / "bnetza_mastr_storage_region.gpkg",
-        outfile_agg=DATASET_PATH / "data" / "bnetza_mastr_storage_agg_region.gpkg"
+        outfile_agg=DATASET_PATH
+        / "data"
+        / "bnetza_mastr_storage_agg_region.gpkg",
     params:
-        config_file=DATASET_PATH / "config.yml"
+        config_file=DATASET_PATH / "config.yml",
     script:
         DATASET_PATH / "scripts" / "create.py"
+
 
 rule create_power_stats_muns:
     """
@@ -46,19 +53,23 @@ rule create_power_stats_muns:
         region_muns=PATH_TO_REGION_MUNICIPALITIES_GPKG,
     output:
         total=DATASET_PATH / "data" / "bnetza_mastr_storage_stats_muns.csv",
-        large=DATASET_PATH/ "data" / "bnetza_mastr_storage_large_stats_muns.csv",
-        small=DATASET_PATH/ "data" / "bnetza_mastr_storage_small_stats_muns.csv",
+        large=DATASET_PATH
+        / "data"
+        / "bnetza_mastr_storage_large_stats_muns.csv",
+        small=DATASET_PATH
+        / "data"
+        / "bnetza_mastr_storage_small_stats_muns.csv",
     run:
         units = gpd.read_file(input.units)
-        units["storage_capacity"] = units["storage_capacity"].div(1e3)  # kW to MW
+        units["storage_capacity"] = units["storage_capacity"].div(
+            1e3
+        )  # kW to MW
         muns = gpd.read_file(input.region_muns)
         print("Battery storages:")
 
         # All storage units
         units_total = create_stats_per_municipality(
-            units_df=units,
-            muns=muns,
-            column="storage_capacity"
+            units_df=units, muns=muns, column="storage_capacity"
         )
         print(
             f"  Storage capacity (total): "
@@ -72,7 +83,7 @@ rule create_power_stats_muns:
                 units.storage_capacity >= config.get("battery_size_threshold")
             ],
             muns=muns,
-            column="storage_capacity"
+            column="storage_capacity",
         )
         print(
             f"  Storage capacity (large): "
@@ -86,13 +97,14 @@ rule create_power_stats_muns:
                 units.storage_capacity < config.get("battery_size_threshold")
             ],
             muns=muns,
-            column="storage_capacity"
+            column="storage_capacity",
         )
         print(
             f"  Storage capacity (small): "
             f"{units_small.storage_capacity.sum().round(3)} MWh"
         )
         units_small.to_csv(output.small)
+
 
 rule create_storage_pv_roof_stats:
     """
@@ -102,7 +114,8 @@ rule create_storage_pv_roof_stats:
     input:
         units=DATASET_PATH / "data" / "bnetza_mastr_storage_region.gpkg",
         pv_roof_units=rules.datasets_bnetza_mastr_pv_roof_region_create.output.outfile,
-    output: DATASET_PATH / "data" / "bnetza_mastr_storage_pv_roof.json"
+    output:
+        DATASET_PATH / "data" / "bnetza_mastr_storage_pv_roof.json",
     run:
         # PV home units: guess PV home systems
         pv_roof_units = gpd.read_file(input.pv_roof_units)[
@@ -110,21 +123,24 @@ rule create_storage_pv_roof_stats:
         ]
         hs_cfg = config.get("home_storages")
         mask = (
-            (pv_roof_units.capacity_net >=
-             hs_cfg.get("pv_roof_capacity_thres_min")) &
-            (pv_roof_units.capacity_net <=
-             hs_cfg.get("pv_roof_capacity_thres_max"))
+            pv_roof_units.capacity_net
+            >= hs_cfg.get("pv_roof_capacity_thres_min")
+        ) & (
+            pv_roof_units.capacity_net
+            <= hs_cfg.get("pv_roof_capacity_thres_max")
         )
         pv_roof_units_small = pv_roof_units.loc[mask]
 
         # Storage units: calc specific values
-        units = gpd.read_file(input.units)[[
-            "capacity_net",
-            "storage_capacity",
-            "mastr_location_id",
-            "pv_roof_unit_count",
-            "pv_roof_unit_capacity_sum"
-        ]]
+        units = gpd.read_file(input.units)[
+            [
+                "capacity_net",
+                "storage_capacity",
+                "mastr_location_id",
+                "pv_roof_unit_count",
+                "pv_roof_unit_capacity_sum",
+            ]
+        ]
         units_unique_loc = units.groupby("mastr_location_id").agg(
             storage_count=("storage_capacity", "count"),
             storage_capacity=("storage_capacity", "sum"),
@@ -135,22 +151,32 @@ rule create_storage_pv_roof_stats:
 
         # Filter storages
         mask = (
-            (units_unique_loc.storage_count == 1
-             if hs_cfg.get("only_single_storages")
-             else units_unique_loc.storage_count > 0
-             ) &
-            (units_unique_loc.storage_capacity <=
-             hs_cfg.get("storage_capacity_thres_max")) &
-            (units_unique_loc.capacity_net <=
-             hs_cfg.get("storage_power_thres_max")) &
-            (units_unique_loc.pv_roof_unit_count == 1
-             if hs_cfg.get("only_single_pv_roof_units")
-             else units_unique_loc.pv_roof_unit_count > 0
-             ) &
-            (units_unique_loc.pv_roof_unit_capacity_sum >=
-             hs_cfg.get("pv_roof_capacity_thres_min")) &
-            (units_unique_loc.pv_roof_unit_capacity_sum <=
-             hs_cfg.get("pv_roof_capacity_thres_max"))
+            (
+                units_unique_loc.storage_count == 1
+                if hs_cfg.get("only_single_storages")
+                else units_unique_loc.storage_count > 0
+            )
+            & (
+                units_unique_loc.storage_capacity
+                <= hs_cfg.get("storage_capacity_thres_max")
+            )
+            & (
+                units_unique_loc.capacity_net
+                <= hs_cfg.get("storage_power_thres_max")
+            )
+            & (
+                units_unique_loc.pv_roof_unit_count == 1
+                if hs_cfg.get("only_single_pv_roof_units")
+                else units_unique_loc.pv_roof_unit_count > 0
+            )
+            & (
+                units_unique_loc.pv_roof_unit_capacity_sum
+                >= hs_cfg.get("pv_roof_capacity_thres_min")
+            )
+            & (
+                units_unique_loc.pv_roof_unit_capacity_sum
+                <= hs_cfg.get("pv_roof_capacity_thres_max")
+            )
         )
         units_unique_loc_small = units_unique_loc.loc[mask]
 
@@ -159,13 +185,12 @@ rule create_storage_pv_roof_stats:
                 {
                     "pv_roof_share": {
                         "all_storages": round(
-                            len(units_unique_loc) /
-                            len(pv_roof_units),
+                            len(units_unique_loc) / len(pv_roof_units),
                             3,
                         ),
                         "home_storages": round(
-                            len(units_unique_loc_small) /
-                            len(pv_roof_units_small),
+                            len(units_unique_loc_small)
+                            / len(pv_roof_units_small),
                             3,
                         ),
                     },

--- a/digipipe/store/datasets/bnetza_mastr_storage_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_storage_region/scripts/create.py
@@ -1,6 +1,7 @@
 import geopandas as gpd
 import pandas as pd
 
+from digipipe.config import GLOBAL_CONFIG
 from digipipe.scripts.datasets import mastr
 from digipipe.scripts.geo import (
     overlay,
@@ -8,10 +9,9 @@ from digipipe.scripts.geo import (
     write_geofile,
 )
 from digipipe.store.utils import (
-    get_names_from_nuts,
     PATH_TO_REGION_DISTRICTS_GPKG,
+    get_names_from_nuts,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:

--- a/digipipe/store/datasets/bnetza_mastr_storage_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_storage_region/scripts/create.py
@@ -7,22 +7,26 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
+    unit_attrs = snakemake.config["unit_attributes"]
+    unit_attrs_filter = snakemake.config["unit_attributes_filter"]
+    unit_attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
     # Read units
     units = pd.read_csv(
         snakemake.input.units,
         usecols=(
-            set(snakemake.config["unit_attributes"].keys())
-            | set(snakemake.config["unit_attributes_filter"].keys())
+            set(unit_attrs.keys())
+            | set(unit_attrs_filter["unit_attributes_filter"].keys())
         ),
         dtype={"Postleitzahl": str},
     )
     units = rename_filter_attributes(
         gdf=units,
-        attrs_filter_by_values=snakemake.config["unit_attributes_filter"],
-        attrs_mapping=snakemake.config["unit_attributes"],
+        attrs_filter_by_values=unit_attrs_filter,
+        attrs_mapping=unit_attrs,
     ).set_index("mastr_id")
 
     # Read plants (for storage capacity)

--- a/digipipe/store/datasets/bnetza_mastr_storage_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_storage_region/scripts/create.py
@@ -19,7 +19,7 @@ def process() -> None:
     unit_attrs_filter = snakemake.config["unit_attributes_filter"]
     unit_attrs_filter["Landkreis"] = get_names_from_nuts(
         PATH_TO_REGION_DISTRICTS_GPKG,
-        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+        GLOBAL_CONFIG["global"]["geodata"]["nuts"],
     )
     # Read units
     units = pd.read_csv(

--- a/digipipe/store/datasets/bnetza_mastr_storage_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_storage_region/scripts/create.py
@@ -7,20 +7,24 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.store.utils import (
+    get_names_from_nuts,
+    PATH_TO_REGION_DISTRICTS_GPKG,
+)
 from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     unit_attrs = snakemake.config["unit_attributes"]
     unit_attrs_filter = snakemake.config["unit_attributes_filter"]
-    unit_attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
+    unit_attrs_filter["Landkreis"] = get_names_from_nuts(
+        PATH_TO_REGION_DISTRICTS_GPKG,
+        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+    )
     # Read units
     units = pd.read_csv(
         snakemake.input.units,
-        usecols=(
-            set(unit_attrs.keys())
-            | set(unit_attrs_filter["unit_attributes_filter"].keys())
-        ),
+        usecols=(set(unit_attrs.keys()) | set(unit_attrs_filter.keys())),
         dtype={"Postleitzahl": str},
     )
     units = rename_filter_attributes(

--- a/digipipe/store/datasets/bnetza_mastr_wind_region/config.yml
+++ b/digipipe/store/datasets/bnetza_mastr_wind_region/config.yml
@@ -34,8 +34,7 @@ attributes:
 attributes_filter:
   {"Land": "Deutschland",
    "EinheitBetriebsstatus": ["In Betrieb", "In Planung"],
-   "Lage": "Windkraft an Land",
-   "Landkreis": ["Wittenberg", "Anhalt-Bitterfeld", "Dessau-Roßlau"]}
+   "Lage": "Windkraft an Land"}
 
 # Output settings
 layer: bnetza_mastr_wind

--- a/digipipe/store/datasets/bnetza_mastr_wind_region/create.smk
+++ b/digipipe/store/datasets/bnetza_mastr_wind_region/create.smk
@@ -83,13 +83,16 @@ rule create_development_over_time:
         )
 
         df_units_cumulative = (
-            df.groupby("year").agg(
-                unit_count=("mastr_id", "count")).cumsum().reset_index()
+            df.groupby("year")
+            .agg(unit_count=("mastr_id", "count"))
+            .cumsum()
+            .reset_index()
         )
         df_combined = df_capacity_over_time.merge(
             df_units_cumulative, on="year"
         )
-        df_combined["capacity_net"] = df_combined[
-            "capacity_net"].div(1e3).round(1)
+        df_combined["capacity_net"] = (
+            df_combined["capacity_net"].div(1e3).round(1)
+        )
         df_combined["year"] = df_combined["year"].astype(int)
         df_combined.to_csv(output[0], index=False)

--- a/digipipe/store/datasets/bnetza_mastr_wind_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_wind_region/scripts/create.py
@@ -7,11 +7,13 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
+    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
 
     units = pd.read_csv(
         snakemake.input.units,

--- a/digipipe/store/datasets/bnetza_mastr_wind_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_wind_region/scripts/create.py
@@ -19,7 +19,7 @@ def process() -> None:
     attrs_filter = snakemake.config["attributes_filter"]
     attrs_filter["Landkreis"] = get_names_from_nuts(
         PATH_TO_REGION_DISTRICTS_GPKG,
-        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+        GLOBAL_CONFIG["global"]["geodata"]["nuts"],
     )
 
     units = pd.read_csv(

--- a/digipipe/store/datasets/bnetza_mastr_wind_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_wind_region/scripts/create.py
@@ -1,6 +1,7 @@
 import geopandas as gpd
 import pandas as pd
 
+from digipipe.config import GLOBAL_CONFIG
 from digipipe.scripts.datasets import mastr
 from digipipe.scripts.geo import (
     overlay,
@@ -8,10 +9,9 @@ from digipipe.scripts.geo import (
     write_geofile,
 )
 from digipipe.store.utils import (
-    get_names_from_nuts,
     PATH_TO_REGION_DISTRICTS_GPKG,
+    get_names_from_nuts,
 )
-from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:

--- a/digipipe/store/datasets/bnetza_mastr_wind_region/scripts/create.py
+++ b/digipipe/store/datasets/bnetza_mastr_wind_region/scripts/create.py
@@ -7,13 +7,20 @@ from digipipe.scripts.geo import (
     rename_filter_attributes,
     write_geofile,
 )
+from digipipe.store.utils import (
+    get_names_from_nuts,
+    PATH_TO_REGION_DISTRICTS_GPKG,
+)
 from digipipe.config import GLOBAL_CONFIG
 
 
 def process() -> None:
     attrs = snakemake.config["attributes"]
     attrs_filter = snakemake.config["attributes_filter"]
-    attrs_filter["NUTS"] = GLOBAL_CONFIG["global"]["geodata"]["NUTS"]
+    attrs_filter["Landkreis"] = get_names_from_nuts(
+        PATH_TO_REGION_DISTRICTS_GPKG,
+        GLOBAL_CONFIG["global"]["geodata"]["NUTS"],
+    )
 
     units = pd.read_csv(
         snakemake.input.units,

--- a/digipipe/store/utils.py
+++ b/digipipe/store/utils.py
@@ -108,7 +108,7 @@ PATH_TO_REGION_DISTRICTS_GPKG = (
 )
 
 
-def get_names_from_nuts(gpkg: gpd.GeoDataFrame, regions_nuts: list) -> list:
+def get_names_from_nuts(gpkg: Path, regions_nuts: list) -> list:
     """
     Extract region names from a GeoPackage file for specified NUTS codes.
 
@@ -118,8 +118,8 @@ def get_names_from_nuts(gpkg: gpd.GeoDataFrame, regions_nuts: list) -> list:
 
     Parameters
     ----------
-    gpkg : gpd.GeoDataFrame
-        A GeoDataFrame representing geographical data from the GeoPackage file.
+    gpkg : pathlib.Path
+        A GeoPackage representing geographical data file.
     regions_nuts : list
         A list of NUTS codes to filter the data by
 

--- a/digipipe/store/utils.py
+++ b/digipipe/store/utils.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 
 import pandas as pd
+import geopandas as gpd
 
 from digipipe import store
 
@@ -105,6 +106,33 @@ PATH_TO_REGION_DISTRICTS_GPKG = (
     )
     / "bkg_vg250_districts_region.gpkg"
 )
+
+
+def get_names_from_nuts(gpkg: gpd.GeoDataFrame, regions_nuts: list) -> list:
+    """
+    Extract region names from a GeoPackage file for specified NUTS codes.
+
+    This function reads a GeoPackage file using GeoPandas, filters the
+    data to select rows where the 'nuts' column matches the provided NUTS
+    codes, and returns a list of region names from the 'name' column
+
+    Parameters
+    ----------
+    gpkg : gpd.GeoDataFrame
+        A GeoDataFrame representing geographical data from the GeoPackage file.
+    regions_nuts : list
+        A list of NUTS codes to filter the data by
+
+    Returns
+    -------
+    list
+        A list of region names corresponding to the provided NUTS codes
+
+    """
+    gdf = gpd.read_file(gpkg)
+    filtered_gdf = gdf[gdf["nuts"].isin(regions_nuts)]
+    regions_names = filtered_gdf["name"].tolist()
+    return regions_names
 
 
 def df_merge_string_columns(

--- a/digipipe/store/utils.py
+++ b/digipipe/store/utils.py
@@ -6,8 +6,8 @@ import inspect
 import os
 from pathlib import Path
 
-import pandas as pd
 import geopandas as gpd
+import pandas as pd
 
 from digipipe import store
 


### PR DESCRIPTION
Adds #44 

## Before merging into `dev`-branch, please make sure that the following points are checked:

- [X] All pre-commit tests passed locally with: `pre-commit run -a`
- [X] File `CHANGELOG.md` was updated
- [ ] The docs were updated
  ~- [ ] if `dataset.md`s were updated, the dataset docs were regenerated using
    `python docs/generate_dataset_mds.py`~

~If packages were modified:~
~- [ ] File `poetry.lock` was updated with: `poetry lock`~
~- [ ] A new env was successfully set up~

WARNING: When modifying use snakemake <=7.32.0, cf. #186

If data flow was adjusted:
- [X] Data pipeline run finished successfully with: `snakemake -jX`
- [ ] Esys appdata was created successfully with: `snakemake -jX make_esys_appdata`
  - ERROR!  
```
Error in rule write_costs_efficiencies:
    jobid: 5
    input: store/datasets/esys_raw/data/scalars/default_costs_efficiencies.csv, store/raw/technology_data/data/raw_costs_efficiencies.csv
    output: store/datasets/esys_raw/data/scalars/costs_efficiencies.csv
    shell:
        python esys/scripts/write_costs_efficiencies.py store/datasets/esys_raw/data/scalars/default_costs_efficiencies.csv store/raw/technology_data/data/raw_costs_efficiencies.csv store/datasets/esys_raw/data/scalars/costs_efficiencies.csv
        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)
```

